### PR TITLE
Fix header readability and adjust fleet gradient

### DIFF
--- a/src/components/FleetPreview.tsx
+++ b/src/components/FleetPreview.tsx
@@ -68,7 +68,7 @@ const FleetPreview: React.FC = () => {
           <div className="relative z-10 text-center py-16 px-6 sm:py-20 sm:px-8 md:py-24 md:px-12">
             <div className="bg-black/30 backdrop-blur-sm rounded-2xl p-8 md:p-12 mx-auto max-w-5xl">
               <h2 className="text-4xl md:text-5xl lg:text-6xl font-black text-white mb-6 text-shadow-strong">
-                Our <span className="text-gradient bg-gradient-to-r from-primary-300 to-primary-200 bg-clip-text text-transparent" style={{ textShadow: '2px 2px 4px rgba(0, 0, 0, 0.9), 0px 0px 8px rgba(0, 0, 0, 0.5)' }}>Premium Fleet</span>
+                Our <span className="text-gradient bg-gradient-to-r from-primary-200 to-primary-50 bg-clip-text text-transparent" style={{ textShadow: '2px 2px 4px rgba(0, 0, 0, 0.9), 0px 0px 8px rgba(0, 0, 0, 0.5)' }}>Premium Fleet</span>
               </h2>
               <p className="text-xl md:text-2xl text-gray-100 max-w-4xl mx-auto leading-relaxed text-shadow-medium">
                 State-of-the-art dump trucks equipped with the latest technology, 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -32,9 +32,9 @@ const Header: React.FC = () => {
       animate={{ y: 0 }}
       transition={{ duration: 0.6, ease: "easeOut" }}
       className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${
-        isScrolled 
-          ? 'bg-white/95 backdrop-blur-md shadow-lg border-b border-gray-200' 
-          : 'bg-transparent'
+        isScrolled
+          ? 'bg-white/95 backdrop-blur-md shadow-lg border-b border-gray-200'
+          : 'bg-black/50 backdrop-blur-md'
       }`}
     >
       <div className="container-custom">
@@ -63,8 +63,12 @@ const Header: React.FC = () => {
                 to={link.path}
                 className={`relative font-medium transition-colors duration-200 ${
                   isActivePath(link.path)
-                    ? 'text-primary-600'
-                    : 'text-gray-700 hover:text-primary-600'
+                    ? isScrolled
+                      ? 'text-primary-600'
+                      : 'text-white'
+                    : isScrolled
+                      ? 'text-gray-700 hover:text-primary-600'
+                      : 'text-gray-100 hover:text-white'
                 }`}
               >
                 {link.name}
@@ -80,7 +84,7 @@ const Header: React.FC = () => {
 
           {/* Contact Info & CTA */}
           <div className="hidden lg:flex items-center space-x-4">
-            <div className="flex items-center space-x-2 text-gray-700">
+            <div className={`flex items-center space-x-2 ${isScrolled ? 'text-gray-700' : 'text-gray-100'}`}>
               <Phone className="h-4 w-4" />
               <span className="font-medium">+1 (819) 588-5472</span>
             </div>
@@ -95,7 +99,7 @@ const Header: React.FC = () => {
           {/* Mobile Menu Button */}
           <button
             onClick={() => setIsMenuOpen(!isMenuOpen)}
-            className="lg:hidden p-2 rounded-lg text-gray-700 hover:bg-gray-100 transition-colors"
+            className={`lg:hidden p-2 rounded-lg transition-colors ${isScrolled ? 'text-gray-700 hover:bg-gray-100' : 'text-gray-100 hover:bg-white/10'}`}
           >
             {isMenuOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
           </button>


### PR DESCRIPTION
## Summary
- enhance header background and link colors when page is at top
- lighten the "Premium Fleet" gradient text

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run build` *(fails: TypeScript errors in ServicesPage.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_687be0f499848320bae12b49b7aa161c