### PR TITLE
Use truck image as header logo

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { Menu, X, Phone } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
-import logo from '../assets/images/IMG_1362.webp';
+import logo from '../assets/images/9A736688-1B31-4F13-84D3-E05C6790849A.png';
 
 const Header: React.FC = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);


### PR DESCRIPTION
## Summary
- update the header to use the provided PNG as the site logo

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config)*

------
https://chatgpt.com/codex/tasks/task_e_687c0ba47da08320b6095547aaa20a39