### PR TITLE
Remove fleet preview from homepage

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import HeroSection from '../components/HeroSection';
 import ServicesOverview from '../components/ServicesOverview';
-import FleetPreview from '../components/FleetPreview';
 import WhyChooseUs from '../components/WhyChooseUs';
 import QuickQuote from '../components/QuickQuote';
 import Testimonials from '../components/Testimonials';
@@ -11,7 +10,6 @@ const HomePage: React.FC = () => {
     <div className="homepage">
       <HeroSection />
       <ServicesOverview />
-      <FleetPreview />
       <WhyChooseUs />
       <QuickQuote />
       <Testimonials />


### PR DESCRIPTION
## Summary
- remove `FleetPreview` component from home page

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: TypeScript errors due to missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_687c227c1b5c832096fa34b56e636136