### PR TITLE
Fix page scroll and mobile effects

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import ScrollToTop from './components/ScrollToTop';
 import Header from './components/Header';
 import Footer from './components/Footer';
 import HomePage from './pages/HomePage';
@@ -10,6 +11,7 @@ import QuotePage from './pages/QuotePage';
 function App() {
   return (
     <Router>
+      <ScrollToTop />
       <div className="App min-h-screen flex flex-col bg-gray-50">
         <Header />
         <main className="flex-1">

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -23,7 +23,7 @@ const HeroSection: React.FC = () => {
       <div className="absolute inset-0 bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900">
         <div className="absolute inset-0 bg-black/40"></div>
         {/* Animated background pattern */}
-        <div className="absolute inset-0 opacity-10">
+        <div className="absolute inset-0 opacity-10 hidden md:block">
           <div className="absolute top-1/4 left-1/4 w-64 h-64 bg-primary-500 rounded-full blur-3xl animate-pulse"></div>
           <div className="absolute bottom-1/4 right-1/4 w-96 h-96 bg-primary-400 rounded-full blur-3xl animate-pulse delay-1000"></div>
         </div>

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const ScrollToTop: React.FC = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;

--- a/src/index.css
+++ b/src/index.css
@@ -74,6 +74,12 @@
       background-size: cover;
       background-position: center top;
     }
+
+    /* Disable heavy backdrop blur on small screens */
+    .glass-effect {
+      backdrop-filter: none;
+      background-color: rgba(255, 255, 255, 0.3);
+    }
   }
   
   /* Image optimization for better performance */


### PR DESCRIPTION
## Summary
- reset scroll position on route change
- hide complex hero background animations on small screens
- disable backdrop blur for glass effect on mobile

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_687d2e3af70c8320b331519a084f54a6